### PR TITLE
Update IIonReader to extend IDisposable

### DIFF
--- a/Amazon.IonDotnet/IIonReader.cs
+++ b/Amazon.IonDotnet/IIonReader.cs
@@ -22,7 +22,7 @@ namespace Amazon.IonDotnet
     /// <summary>
     /// Provides stream-based access to Ion data independent of its underlying representation (text, binary, or {@link IonValue} tree).
     /// </summary>
-    public interface IIonReader
+    public interface IIonReader : IDisposable
     {
         /// <summary>
         /// Positions this reader on the next sibling after the current value

--- a/Amazon.IonDotnet/Internals/Binary/RawBinaryReader.cs
+++ b/Amazon.IonDotnet/Internals/Binary/RawBinaryReader.cs
@@ -135,6 +135,11 @@ namespace Amazon.IonDotnet.Internals.Binary
             _hasSymbolTableAnnotation = false;
         }
 
+        public void Dispose()
+        {
+            // Nothing to dispose for now
+        }
+
         private void MoveNextRaw()
         {
             ClearValue();

--- a/Amazon.IonDotnet/Internals/Binary/RawBinaryReader.cs
+++ b/Amazon.IonDotnet/Internals/Binary/RawBinaryReader.cs
@@ -136,7 +136,7 @@ namespace Amazon.IonDotnet.Internals.Binary
         }
 
         /// <summary>
-        /// Dispose RawBinaryReader. No-op.
+        /// Dispose RawBinaryReader.
         /// </summary>
         public void Dispose()
         {

--- a/Amazon.IonDotnet/Internals/Binary/RawBinaryReader.cs
+++ b/Amazon.IonDotnet/Internals/Binary/RawBinaryReader.cs
@@ -135,9 +135,12 @@ namespace Amazon.IonDotnet.Internals.Binary
             _hasSymbolTableAnnotation = false;
         }
 
+        /// <summary>
+        /// Dispose RawBinaryReader. No-op.
+        /// </summary>
         public void Dispose()
         {
-            // Nothing to dispose for now
+            return;
         }
 
         private void MoveNextRaw()

--- a/Amazon.IonDotnet/Internals/Binary/SymbolTableReader.cs
+++ b/Amazon.IonDotnet/Internals/Binary/SymbolTableReader.cs
@@ -542,7 +542,7 @@ namespace Amazon.IonDotnet.Internals.Binary
         }
 
         /// <summary>
-        /// Dispose SymbolTableReader. No-op.
+        /// Dispose SymbolTableReader.
         /// </summary>
         public void Dispose()
         {

--- a/Amazon.IonDotnet/Internals/Binary/SymbolTableReader.cs
+++ b/Amazon.IonDotnet/Internals/Binary/SymbolTableReader.cs
@@ -541,9 +541,12 @@ namespace Amazon.IonDotnet.Internals.Binary
             yield break;
         }
 
+        /// <summary>
+        /// Dispose SymbolTableReader. No-op.
+        /// </summary>
         public void Dispose()
         {
-            // Nothing to dispose for now
+            return;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Amazon.IonDotnet/Internals/Binary/SymbolTableReader.cs
+++ b/Amazon.IonDotnet/Internals/Binary/SymbolTableReader.cs
@@ -541,6 +541,11 @@ namespace Amazon.IonDotnet.Internals.Binary
             yield break;
         }
 
+        public void Dispose()
+        {
+            // Nothing to dispose for now
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SetFlag(int flagBit, bool on)
         {

--- a/Amazon.IonDotnet/Internals/Text/RawTextReader.cs
+++ b/Amazon.IonDotnet/Internals/Text/RawTextReader.cs
@@ -858,6 +858,11 @@ namespace Amazon.IonDotnet.Internals.Text
             }
         }
 
+        public virtual void Dispose()
+        {
+            // Nothing to dispose for now
+        }
+
         private class ContainerStack
         {
             private readonly RawTextReader _rawTextReader;

--- a/Amazon.IonDotnet/Internals/Text/RawTextReader.cs
+++ b/Amazon.IonDotnet/Internals/Text/RawTextReader.cs
@@ -859,7 +859,7 @@ namespace Amazon.IonDotnet.Internals.Text
         }
 
         /// <summary>
-        /// Dispose RawTextReader. No-op.
+        /// Dispose RawTextReader.
         /// </summary>
         public virtual void Dispose()
         {

--- a/Amazon.IonDotnet/Internals/Text/RawTextReader.cs
+++ b/Amazon.IonDotnet/Internals/Text/RawTextReader.cs
@@ -858,9 +858,12 @@ namespace Amazon.IonDotnet.Internals.Text
             }
         }
 
+        /// <summary>
+        /// Dispose RawTextReader. No-op.
+        /// </summary>
         public virtual void Dispose()
         {
-            // Nothing to dispose for now
+            return;
         }
 
         private class ContainerStack

--- a/Amazon.IonDotnet/Internals/Tree/SystemTreeReader.cs
+++ b/Amazon.IonDotnet/Internals/Tree/SystemTreeReader.cs
@@ -259,9 +259,12 @@ namespace Amazon.IonDotnet.Internals.Tree
             return _current.TimestampValue;
         }
 
+        /// <summary>
+        /// Dispose SystemTreeReader. No-op.
+        /// </summary>
         public virtual void Dispose()
         {
-            // Nothing to dispose for now
+            return;
         }
 
         internal class Children : IEnumerator<IIonValue>

--- a/Amazon.IonDotnet/Internals/Tree/SystemTreeReader.cs
+++ b/Amazon.IonDotnet/Internals/Tree/SystemTreeReader.cs
@@ -259,6 +259,11 @@ namespace Amazon.IonDotnet.Internals.Tree
             return _current.TimestampValue;
         }
 
+        public virtual void Dispose()
+        {
+            // Nothing to dispose for now
+        }
+
         internal class Children : IEnumerator<IIonValue>
         {
             bool _eof;

--- a/Amazon.IonDotnet/Internals/Tree/SystemTreeReader.cs
+++ b/Amazon.IonDotnet/Internals/Tree/SystemTreeReader.cs
@@ -260,7 +260,7 @@ namespace Amazon.IonDotnet.Internals.Tree
         }
 
         /// <summary>
-        /// Dispose SystemTreeReader. No-op.
+        /// Dispose SystemTreeReader.
         /// </summary>
         public virtual void Dispose()
         {

--- a/Amazon.IonDotnet/Internals/Tree/UserTreeReader.cs
+++ b/Amazon.IonDotnet/Internals/Tree/UserTreeReader.cs
@@ -116,9 +116,12 @@ namespace Amazon.IonDotnet.Internals.Tree
             return (nextType != IonType.None);
         }
 
+        /// <summary>
+        /// Dispose UserTreeReader. No-op.
+        /// </summary>
         public override void Dispose()
         {
-            // Nothing to dispose for now
+            return;
         }
 
         private void ClearSystemValueStack()

--- a/Amazon.IonDotnet/Internals/Tree/UserTreeReader.cs
+++ b/Amazon.IonDotnet/Internals/Tree/UserTreeReader.cs
@@ -116,6 +116,11 @@ namespace Amazon.IonDotnet.Internals.Tree
             return (nextType != IonType.None);
         }
 
+        public override void Dispose()
+        {
+            // Nothing to dispose for now
+        }
+
         private void ClearSystemValueStack()
         {
             while (_symbolTableTop > 0)

--- a/Amazon.IonDotnet/Internals/Tree/UserTreeReader.cs
+++ b/Amazon.IonDotnet/Internals/Tree/UserTreeReader.cs
@@ -117,7 +117,7 @@ namespace Amazon.IonDotnet.Internals.Tree
         }
 
         /// <summary>
-        /// Dispose UserTreeReader. No-op.
+        /// Dispose UserTreeReader.
         /// </summary>
         public override void Dispose()
         {

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package is based on work from Huy Hoang ([dhhoang](https://github.com/dhhoa
 
 ### Manual read/write
 
-You can create a `reader` that can read from a (input) stream. You can specify text encoding in the `ReaderOptions`, otherwise Utf8 will be used by default. There are 4 different `reader`s that you can create - examples are as listed below. 
+You can create a `reader` that can read from a (input) stream. You can specify text encoding in the `ReaderOptions`, otherwise Utf8 will be used by default. There are two different `reader`s that you can create, binary and text. Four `reader` objects are created below with different inputs. 
 ```csharp
 Stream stream;  //input stream
 String text;    //text form
@@ -53,8 +53,7 @@ using (IIonReader reader = IonReaderBuilder.Build(stream))
 }
 ```
 
-Similarly you can create a writer that write to a (output) stream. There are 3 different `writer`s that you can create - examples are as listed below. 
-
+Similarly you can create a writer that write to a (output) stream. There are two different `writer`s that you can create, binary and text. Three `writer` objects are created below with different inputs. 
 ```csharp
 Stream stream; //output stream
 var stringWriter = new StringWriter();

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package is based on work from Huy Hoang ([dhhoang](https://github.com/dhhoa
 
 ### Manual read/write
 
-You can create a `reader` that can read from a (input) stream. You can specify text encoding in the `ReaderOptions`, otherwise Utf8 will be used by default.
+You can create a `reader` that can read from a (input) stream. You can specify text encoding in the `ReaderOptions`, otherwise Utf8 will be used by default. There are 4 different `reader`s that you can create - examples are as listed below. 
 ```csharp
 Stream stream;  //input stream
 String text;    //text form
@@ -28,8 +28,10 @@ reader = IonReaderBuilder.Build(stream, new ReaderOptions {Format = ReaderFormat
 
 //create a text reader that reads a string and uses a catalog
 reader = IonReaderBuilder.Build(text, new ReaderOptions {Catalog = catalog});
+```
 
-
+Example  of using a  `reader`.
+```csharp
 /*reader semantics for
 {
     number: 1,
@@ -37,7 +39,7 @@ reader = IonReaderBuilder.Build(text, new ReaderOptions {Catalog = catalog});
 }
 */
 
-using (reader)
+using (IIonReader reader = IonReaderBuilder.Build(stream))
 {
     Console.WriteLine(reader.MoveNext()); // Struct
     reader.StepIn();
@@ -51,13 +53,14 @@ using (reader)
 }
 ```
 
-Similarly you can create a writer that write to a (output) stream.
+Similarly you can create a writer that write to a (output) stream. There are 3 different `writer`s that you can create - examples are as listed below. 
 
 ```csharp
 Stream stream; //output stream
 var stringWriter = new StringWriter();
 IIonWriter writer;
 ISymbolTable table1,table2;
+
 
 //create a text writer that write to the stream.
 writer = IonTextWriterBuilder.Build(new StreamWriter(stream));
@@ -68,6 +71,10 @@ writer = IonTextWriterBuilder.Build(stringWriter);
 //create a binary writer using multiple symbol tables
 writer = IonBinaryWriterBuilder.Build(stream, new []{table1,table2});
 
+```
+
+Example  of using a  `writer`.
+```csharp
 /*writer semantics for
 {
     number: 1,
@@ -75,7 +82,7 @@ writer = IonBinaryWriterBuilder.Build(stream, new []{table1,table2});
 }
 */
 
-using (writer)
+using (IIonWriter writer = IonTextWriterBuilder.Build(new StreamWriter(stream)))
 {
     writer.StepIn(IonType.Struct);
     writer.SetFieldName("number");

--- a/README.md
+++ b/README.md
@@ -36,15 +36,19 @@ reader = IonReaderBuilder.Build(text, new ReaderOptions {Catalog = catalog});
     text: "hello world"
 }
 */
-Console.WriteLine(reader.MoveNext()); // Struct
-reader.StepIn();
-Console.WriteLine(reader.MoveNext()); // Int
-Console.WriteLine(reader.CurrentFieldName); // "number"
-Console.WriteLine(reader.IntValue());   // 1
-Console.WriteLine(reader.MoveNext()); // String
-Console.WriteLine(reader.CurrentFieldName); // "text"
-Console.WriteLine(reader.StringValue());   // "hello world"
-reader.StepOut();
+
+using (reader)
+{
+    Console.WriteLine(reader.MoveNext()); // Struct
+    reader.StepIn();
+    Console.WriteLine(reader.MoveNext()); // Int
+    Console.WriteLine(reader.CurrentFieldName); // "number"
+    Console.WriteLine(reader.IntValue());   // 1
+    Console.WriteLine(reader.MoveNext()); // String
+    Console.WriteLine(reader.CurrentFieldName); // "text"
+    Console.WriteLine(reader.StringValue());   // "hello world"
+    reader.StepOut();
+}
 ```
 
 Similarly you can create a writer that write to a (output) stream.
@@ -70,13 +74,17 @@ writer = IonBinaryWriterBuilder.Build(stream, new []{table1,table2});
     text: "hello world"
 }
 */
-writer.StepIn(IonType.Struct);
-writer.SetFieldName("number");
-writer.WriteInt(1);
-writer.SetFieldName("text");
-writer.WriteString("hello world");
-writer.StepOut();
-writer.Finish();    //this is important
+
+using (writer)
+{
+    writer.StepIn(IonType.Struct);
+    writer.SetFieldName("number");
+    writer.WriteInt(1);
+    writer.SetFieldName("text");
+    writer.WriteString("hello world");
+    writer.StepOut();
+    writer.Finish();    //this is important
+}
 ```
 
 ### Serialization


### PR DESCRIPTION
Extend IDisposable to IIonReader 
- Added the (empty) method to the reader classes, nothing to dispose of currently. 
- Updated Readme examples with "using"

ion-dotnet issue #70