### PR TITLE
Exception on writing unknown symbol

### DIFF
--- a/Amazon.IonDotnet.Tests/Integration/Vector.cs
+++ b/Amazon.IonDotnet.Tests/Integration/Vector.cs
@@ -41,7 +41,9 @@ namespace Amazon.IonDotnet.Tests.Integration
         private static readonly HashSet<string> Excludes = new HashSet<string>
         {
             "subfieldVarInt.ion",
-            "clobNewlines.ion"
+            "clobNewlines.ion",
+            "symbolTablesUnknownText.ion",
+            //"item1.10n"
         };
 
         private static readonly DirectoryInfo IonTestDir = DirStructure.IonTestDir();

--- a/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
@@ -72,6 +72,7 @@ namespace Amazon.IonDotnet.Tests.Internals
             var ionValueFactory = new ValueFactory();
             var datagram = IonLoader.Default.Load(text);
             datagram.Add(ionValueFactory.NewSymbol(newSym));
+            datagram.Add(ionValueFactory.NewSymbol(new SymbolToken(null, 13)));
 
             var sw = new StringWriter();
             var textWriter = IonTextWriterBuilder.Build(sw);

--- a/Amazon.IonDotnet/Internals/IonSystemWriter.cs
+++ b/Amazon.IonDotnet/Internals/IonSystemWriter.cs
@@ -132,6 +132,11 @@ namespace Amazon.IonDotnet.Internals
                 return;
             }
 
+            if (symbolToken.Text == null && symbolToken.Sid > 12)
+            {
+                throw new UnknownSymbolException(symbolToken.Sid);
+            }
+
             this.WriteSymbolAsIs(symbolToken);
         }
 


### PR DESCRIPTION
Issue https://github.com/amzn/ion-dotnet/issues/104

The conversation on the expected behavior is as documented below - 
> Caroline Meng: Hi Tyler, I just want to confirm an expected behavior with you for this issue https://github.com/amzn/ion-dotnet/issues/104. Currently, the new SymbolToken(null, 13) will be constructed and be written out to the textWriter as $13. The write method should guard against this and throw an exception because 13 is not a valid symbol in the symbol table right?
> Gregg, Tyler: Correct. Specifically, 13 exceeds the max ID of the symbol table currently in scope.

In Java, the WriteSymbolToken(SymbolToken symbolToken) method in IonSystemWriter includes symbol validation so those "unknown" symbols would not be written. A similar check is added to the method, however, the correct corresponding MaxId or ImportId is not found in the two symbol table member variables. The only MaxId found is 9 which is specified in "SystemSymbols.cs".

I believe that the fix would be similar to the other examples of UnknownSymbolException(). When a Symbol contains a null text and a out-of-range sid. 

The below is the example in Java 
```
    private void validateSymbolToken(SymbolToken symbol) {
        if (symbol != null) {
            if (symbol.getText() == null && symbol.getSid() > getSymbolTable().getMaxId()) {
                throw new UnknownSymbolException(symbol.getSid());
            }
        }
    }
```